### PR TITLE
Fixed ServiceWorker DriverInterface Issue

### DIFF
--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -11,6 +11,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Magento\Framework\Filesystem\DriverInterface" type="Magento\Framework\Filesystem\Driver\File" />
     <virtualType name="ScandiPWA\Router\Controller\ConfigurableRouter" type="ScandiPWA\Router\Controller\Router">
         <arguments>
             <argument name="ignoredURLs" xsi:type="array">


### PR DESCRIPTION
Fixes scandipwa/scandipwa#3308

`Dotdigitalgroup_Email` configures correct preference for `Magento\Framework\Filesystem\DriverInterface`.
When it's off, preference is removed from the DI configuration and error appears.

Added same preferene to the ServiceWorker `di.xml`.